### PR TITLE
style(initial config): aplicar estilo de texto verde a párrafo en Home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 export default function Home() {
   return (
    <div>
-    <p>hello Lingo</p>
+    <p className="text-green-500">hello Lingo</p>
    </div>
   );
 }


### PR DESCRIPTION
Se actualizó el componente Home para que el segundo párrafo utilice la clase 
`text-green-500`, añadiendo color verde al texto. Esto mejora la visibilidad 
y consistencia con la paleta de Tailwind CSS.
